### PR TITLE
fix: Update Dockerfile base image to resolve build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn clean package -DskipTests
 
 
 # Stage 2: Create the final runtime image
-FROM openjdk:17-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
 
 # Create a non-root user and group


### PR DESCRIPTION
Changed the final stage base image in the Dockerfile from `openjdk:17-jre-alpine` to `eclipse-temurin:17-jre-alpine`.

This change addresses an error where the `openjdk:17-jre-alpine` image could not be found, likely due to changes in available tags on Docker Hub. The `eclipse-temurin:17-jre-alpine` image is a compatible alternative providing OpenJDK 17 JRE on Alpine Linux.

No changes to application functionality or README were necessary for this fix.