### PR TITLE
fix: Resolve Maven test compilation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Spring Security Test for testing security features -->
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Thymeleaf Extras for Java 8 Time API -->
     <dependency>
       <groupId>org.thymeleaf.extras</groupId>

--- a/src/test/java/com/example/todo/controller/TodoControllerIntegrationTest.java
+++ b/src/test/java/com/example/todo/controller/TodoControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays; // Added this import
 import java.util.List;
 import java.util.Optional;
 
@@ -315,7 +316,7 @@ public class TodoControllerIntegrationTest {
         // Task 6
         createAndSaveTodo("Task Echo (No Due Date, High, Pending)", false, null, Priority.HIGH, null);
         // Task 7 (New specific date task for testing, Newest creation date)
-        createAndSaveTodo("Task Golf (Specific Date, Medium, Pending)", false, LocalDate.now().plusYears(1).withMonth(3).withDay(15), Priority.MEDIUM, null);
+        createAndSaveTodo("Task Golf (Specific Date, Medium, Pending)", false, LocalDate.now().plusYears(1).withMonth(3).withDayOfMonth(15), Priority.MEDIUM, null);
 
         // Expected order for default sort (creationDate ASC): Charlie, Delta, Bravo, Alpha, Foxtrot, Echo, Golf
         // Expected order for creationDate DESC: Golf, Echo, Foxtrot, Alpha, Bravo, Delta, Charlie
@@ -468,7 +469,7 @@ public class TodoControllerIntegrationTest {
     @Test
     void testFilterByDueDate_SpecificDate() throws Exception {
         setupFilterSortTestData();
-        LocalDate specificTestDate = LocalDate.now().plusYears(1).withMonth(3).withDay(15);
+        LocalDate specificTestDate = LocalDate.now().plusYears(1).withMonth(3).withDayOfMonth(15);
         String specificDateStr = specificTestDate.format(DateTimeFormatter.ISO_DATE);
 
         mockMvc.perform(get("/").param("filterByDueDate", specificDateStr))


### PR DESCRIPTION
This commit addresses several compilation errors that were occurring during the Maven test compilation phase, primarily in `TodoControllerIntegrationTest.java`.

The following fixes were implemented:

1.  **Corrected `LocalDate` method call:**
    *   Replaced all instances of `someLocalDate.withDay(day)` with
        `someLocalDate.withDayOfMonth(day)` in
        `TodoControllerIntegrationTest.java`. The `withDay()` method
        does not exist for `java.time.LocalDate`.

2.  **Added missing import for `java.util.Arrays`:**
    *   Added `import java.util.Arrays;` to
        `TodoControllerIntegrationTest.java` to resolve errors where
        `Arrays.asList()` was used without the class being imported.

3.  **Added `spring-security-test` dependency to `pom.xml`:**
    *   Included the `spring-security-test` dependency with `<scope>test</scope>`.
        This resolves errors related to the missing package
        `org.springframework.security.test.web.servlet.request`, which is
        needed for test utilities like `SecurityMockMvcRequestPostProcessors.csrf()`.

These changes should allow the Maven build to compile all test sources successfully.